### PR TITLE
Update gcp service account creds json

### DIFF
--- a/customer/gcp-svc-account.json
+++ b/customer/gcp-svc-account.json
@@ -8,5 +8,6 @@
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
   "token_uri": "https://oauth2.googleapis.com/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/endor%40endor-experiments.iam.gserviceaccount.com"
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/endor%40endor-experiments.iam.gserviceaccount.com",
+  "universe_domain": "googleapis.com"
 }


### PR DESCRIPTION
The regex for `gcp-service-account` rule has been updated to include `universe_domain` field in the GCP service account credentials json.
This PR updates `customer/gcp-svc-account.json` to include this new field. 