### PR TITLE
Add GHSA id to false positives

### DIFF
--- a/false_positives/ghsa.yaml
+++ b/false_positives/ghsa.yaml
@@ -1,0 +1,1 @@
+extra_key: "GHSA-q485-j897-qc27"


### PR DESCRIPTION
GHSA ids are getting detected as generic-api-key when defined in code like: 
`key: "GHSA-q485-j897-qc27"` 

Adding it to false positives with this PR.
